### PR TITLE
feature: add support for TinyGo UART alongside standard OS serial ports.

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -7,8 +7,6 @@ import (
 	"maps"
 	"sync"
 	"time"
-
-	"go.bug.st/serial"
 )
 
 // Protocol constants
@@ -73,7 +71,7 @@ const (
 
 // Bus represents a Feetech servo bus
 type Bus struct {
-	port         serial.Port
+	port         serialPort
 	portName     string
 	protocol     int
 	timeout      time.Duration
@@ -114,14 +112,7 @@ func NewBus(config BusConfig) (*Bus, error) {
 		return nil, fmt.Errorf("unsupported protocol version: %d", config.Protocol)
 	}
 
-	mode := &serial.Mode{
-		BaudRate: config.Baudrate,
-		DataBits: 8,
-		Parity:   serial.NoParity,
-		StopBits: serial.OneStopBit,
-	}
-
-	port, err := serial.Open(config.Port, mode)
+	port, err := OpenPort(config.Port, config.Baudrate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open port %s: %w", config.Port, err)
 	}

--- a/port.go
+++ b/port.go
@@ -1,0 +1,11 @@
+package feetech
+
+import "time"
+
+// serialPort interface allows using either OS serial port or UART on microcontroller.
+type serialPort interface {
+	Read(p []byte) (n int, err error)
+	Write(p []byte) (n int, err error)
+	SetReadTimeout(t time.Duration) error
+	Close() error
+}

--- a/port_mcu.go
+++ b/port_mcu.go
@@ -1,0 +1,38 @@
+//go:build baremetal
+
+package feetech
+
+import (
+	"errors"
+	"machine"
+	"time"
+)
+
+type mcuPort struct {
+	*machine.UART
+}
+
+var currentPort mcuPort
+
+func OpenPort(port string, baud int) (*mcuPort, error) {
+	switch port {
+	case "0":
+		currentPort = mcuPort{machine.UART0}
+		return &currentPort, nil
+	case "1":
+		currentPort = mcuPort{machine.UART1}
+	default:
+		return nil, errors.New("unknown UART")
+	}
+
+	currentPort.SetBaudRate(uint32(baud))
+	return &currentPort, nil
+}
+
+func (port *mcuPort) SetReadTimeout(t time.Duration) error {
+	return nil
+}
+
+func (port *mcuPort) Close() error {
+	return nil
+}

--- a/port_os.go
+++ b/port_os.go
@@ -1,0 +1,27 @@
+//go:build !baremetal
+
+package feetech
+
+import (
+	"fmt"
+
+	"go.bug.st/serial"
+)
+
+type osPort serial.Port
+
+func OpenPort(port string, baud int) (osPort, error) {
+	mode := &serial.Mode{
+		BaudRate: baud,
+		DataBits: 8,
+		Parity:   serial.NoParity,
+		StopBits: serial.OneStopBit,
+	}
+
+	p, err := serial.Open(port, mode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open port %s: %w", port, err)
+	}
+
+	return p, nil
+}


### PR DESCRIPTION
This PR is intended to add support for TinyGo `machine.UART` alongside the standard OS serial ports that are already supported. It lets you run this package to control servos directly from a connected microcontroller.

For example, you can compile for a RP2040 Pico:

```shell
$ tinygo build -o simple.uf2 -target pico -size short .
   code    data     bss |   flash     ram
  80552    5736    5728 |   86288   11464
```

using the following code:

```go
package main

import (
	"log"
	"time"

	"github.com/hipsterbrown/feetech-servo"
)

func main() {
	// Creates a new servo bus on machine.UART0
	bus, err := feetech.NewBus(feetech.BusConfig{
		Port:     "0",
		Baudrate: 1000000,
		Protocol: feetech.ProtocolV0,
		Timeout:  time.Second,
	})
	if err != nil {
		log.Fatal("Failed to create bus:", err)
	}
	defer bus.Close()

	// Create a servo instance
	servo := bus.Servo(1) // Servo with ID 1 (defaults to STS3215)

	// Ping the servo and auto-detect model
	modelNum, err := servo.PingAndDetect()
	if err != nil {
		log.Fatal("Failed to ping servo:", err)
	}
	log.Printf("Connected to servo model: %s (number: %d)", servo.Model, modelNum)

	// Enable torque and move to center position
	if err := servo.SetTorqueEnable(true); err != nil {
		log.Fatal("Failed to enable torque:", err)
	}

	if err := servo.WritePosition(2048.0, false); err != nil { // Raw position
		log.Fatal("Failed to write position:", err)
	}

	log.Println("Servo moved to center position")
}
```