### PR TITLE
transports: use typed UART device instead of string port in MCUTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,11 +598,18 @@ func main() {
 	println("Starting servo example...")
 	ctx := context.Background()
 
+	// Create a new servo transport
+	transport, err := transports.OpenSerial(transports.SerialConfig{
+		Device:   machine.UART0,
+		BaudRate: 1000000,
+	})
+	if err != nil {
+		failure("Failed to open serial transport:" + err.Error())
+	}
 	// Create a new servo bus
 	bus, err := feetech.NewBus(feetech.BusConfig{
-		Port:     "0",
-		BaudRate: 1000000,
-		Protocol: feetech.ProtocolSTS,
+		Transport: transport,
+		Protocol:  feetech.ProtocolSTS,
 	})
 	if err != nil {
 		failure("Failed to create bus:" + err.Error())

--- a/transports/serial_mcu.go
+++ b/transports/serial_mcu.go
@@ -4,7 +4,6 @@ package transports
 
 import (
 	"errors"
-	"fmt"
 	"machine"
 	"time"
 )
@@ -14,7 +13,8 @@ type MCUTransport struct {
 }
 
 type SerialConfig struct {
-	Port     string
+	Device   *machine.UART
+	Port     string // Ignored on MCU, but required for interface compatibility
 	BaudRate int
 	Timeout  time.Duration
 }
@@ -23,8 +23,8 @@ var currentTransport MCUTransport
 
 // OpenSerial gets a UART port with the given configuration.
 func OpenSerial(cfg SerialConfig) (*MCUTransport, error) {
-	if cfg.Port == "" {
-		return nil, errors.New("serial port path is required")
+	if cfg.Device == nil {
+		return nil, errors.New("UART device is required")
 	}
 
 	if cfg.BaudRate == 0 {
@@ -35,15 +35,7 @@ func OpenSerial(cfg SerialConfig) (*MCUTransport, error) {
 		cfg.Timeout = time.Second
 	}
 
-	switch cfg.Port {
-	case "0":
-		currentTransport = MCUTransport{machine.UART0}
-	case "1":
-		currentTransport = MCUTransport{machine.UART1}
-	default:
-		return nil, fmt.Errorf("unknown UART %s", cfg.Port)
-	}
-
+	currentTransport = MCUTransport{cfg.Device}
 	currentTransport.SetBaudRate(uint32(cfg.BaudRate))
 
 	return &currentTransport, nil


### PR DESCRIPTION
Replaces the string-based `Port` field (e.g. "0", "1") with a typed `*machine.UART` field in `SerialConfig` for MCU serial transport.

This avoids the problem of build failures due to devices not having those exact ports and also makes the API more explicit. For example, if a board only has a single UART the compile was failing due to the missing reference.

The `Port` field is still needed for interface compatibility but is ignored on MCU. Also updated the README example to match this change.